### PR TITLE
Rozbudowa obsługi wyjątków

### DIFF
--- a/backend/src/main/java/org/polsl/backend/config/ControllerExceptionHandler.java
+++ b/backend/src/main/java/org/polsl/backend/config/ControllerExceptionHandler.java
@@ -1,6 +1,7 @@
 package org.polsl.backend.config;
 
 import org.polsl.backend.dto.ApiBasicResponse;
+import org.polsl.backend.exception.BadRequestException;
 import org.polsl.backend.exception.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;
@@ -33,4 +34,17 @@ public class ControllerExceptionHandler {
     return new ApiBasicResponse(false, e.getMessage());
   }
 
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(BadRequestException.class)
+  @ResponseBody
+  ApiBasicResponse handleBadRequestException(BadRequestException e) {
+    return new ApiBasicResponse(false, e.getMessage());
+  }
+
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(NumberFormatException.class)
+  @ResponseBody
+  ApiBasicResponse handleNumberFormatException(NumberFormatException e) {
+    return new ApiBasicResponse(false, "Podana wartość nie jest liczbą");
+  }
 }

--- a/backend/src/main/java/org/polsl/backend/exception/BadRequestException.java
+++ b/backend/src/main/java/org/polsl/backend/exception/BadRequestException.java
@@ -1,0 +1,13 @@
+package org.polsl.backend.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class BadRequestException extends RuntimeException {
+
+  public BadRequestException(String message) {
+    super(message);
+  }
+
+}

--- a/backend/src/test/java/org/polsl/backend/HardwareControllerIntegrationTest.java
+++ b/backend/src/test/java/org/polsl/backend/HardwareControllerIntegrationTest.java
@@ -71,7 +71,9 @@ public class HardwareControllerIntegrationTest {
   @Test
   public void givenInvalidParameter_whenGettingOneHardware_thenReturnStatus400() throws Exception {
     mvc.perform(get("/api/hardware/mvvm"))
-        .andExpect(status().is(400));
+        .andExpect(status().is(400))
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.message").value("Podana wartość nie jest liczbą"));
   }
 
   @Test


### PR DESCRIPTION
Od teraz obsługiwany jest wyjątek `NumberFormatException` (rzucany np wtedy, gdy zamiast podać ID w urlu podamy jakiś napis) oraz można rzucać `BadRequestException`.