### PR TITLE
Wyodrębnienie metody generującej nazwę przynależności

### DIFF
--- a/backend/src/main/java/org/polsl/backend/service/AffiliationService.java
+++ b/backend/src/main/java/org/polsl/backend/service/AffiliationService.java
@@ -25,7 +25,7 @@ public class AffiliationService {
     this.affiliationRepository = affiliationRepository;
   }
 
-  public String generateName(Affiliation affiliation) {
+  public static String generateName(Affiliation affiliation) {
     StringBuilder stringBuilder = new StringBuilder();
     boolean isSeparatorNeeded = false;
     if (!Objects.equals(affiliation.getFirstName(), "")) {

--- a/backend/src/main/java/org/polsl/backend/service/AffiliationService.java
+++ b/backend/src/main/java/org/polsl/backend/service/AffiliationService.java
@@ -25,32 +25,36 @@ public class AffiliationService {
     this.affiliationRepository = affiliationRepository;
   }
 
+  public String generateName(Affiliation affiliation) {
+    StringBuilder stringBuilder = new StringBuilder();
+    boolean isSeparatorNeeded = false;
+    if (!Objects.equals(affiliation.getFirstName(), "")) {
+      stringBuilder.append(affiliation.getFirstName());
+      isSeparatorNeeded = true;
+    }
+    if (!Objects.equals(affiliation.getLastName(), "")) {
+      if (isSeparatorNeeded) {
+        stringBuilder.append(" ");
+      }
+      stringBuilder.append(affiliation.getLastName());
+      isSeparatorNeeded = true;
+    }
+    if (!Objects.equals(affiliation.getLocation(), "")) {
+      if (isSeparatorNeeded) {
+        stringBuilder.append(" - ");
+      }
+      stringBuilder.append(affiliation.getLocation());
+    }
+    return stringBuilder.toString();
+  }
+
   public PaginatedResult<AffiliationOutputDTO> getAllAffiliations() {
     Iterable<Affiliation> affiliations = affiliationRepository.findAllByIsDeletedIsFalse();
     List<AffiliationOutputDTO> dtos = new ArrayList<>();
     for (Affiliation affiliation : affiliations) {
       AffiliationOutputDTO dto = new AffiliationOutputDTO();
       dto.setId(affiliation.getId());
-      StringBuilder stringBuilder = new StringBuilder();
-      boolean isSeparatorNeeded = false;
-      if (!Objects.equals(affiliation.getFirstName(), "")) {
-        stringBuilder.append(affiliation.getFirstName());
-        isSeparatorNeeded = true;
-      }
-      if (!Objects.equals(affiliation.getLastName(), "")) {
-        if (isSeparatorNeeded) {
-          stringBuilder.append(" ");
-        }
-        stringBuilder.append(affiliation.getLastName());
-        isSeparatorNeeded = true;
-      }
-      if (!Objects.equals(affiliation.getLocation(), "")) {
-        if (isSeparatorNeeded) {
-          stringBuilder.append(" - ");
-        }
-        stringBuilder.append(affiliation.getLocation());
-      }
-      dto.setName(stringBuilder.toString());
+      dto.setName(generateName(affiliation));
       dtos.add(dto);
     }
     PaginatedResult<AffiliationOutputDTO> response = new PaginatedResult<>();


### PR DESCRIPTION
Dzięki temu inne osoby będą mogły generować nazwę dla przynależności w swoich serwisach, np po to, żeby w swojej klasie listy DTO przekazywać nazwę powiązanej przynależności. Daj znać, co o tym sądzisz - czy to dobre miejsce i czy metoda może być statyczna.