### PR TITLE
Ignorowanie warningów pochodzących z bibliotek

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -34,4 +34,25 @@ const styles = StyleSheet.create({
   },
 });
 
+// ignorowanie warningów pochodzących z bibliotek
+const warnedComponents = ['ScrollView', 'TouchableOpacity'];
+const defineNewConsole = (oldConsole => ({
+  log: text => oldConsole.log(text),
+  info: text => oldConsole.info(text),
+  warn: text => {
+    let shouldIgnore = false;
+    warnedComponents.forEach((name) => {
+      if (text.includes(name) && text.includes('Please update the following components:')) {
+        shouldIgnore = true;
+      }
+    });
+    if (!shouldIgnore) {
+      oldConsole.warn(text);
+    }
+  },
+  error: text => oldConsole.error(text)
+}));
+window.console = defineNewConsole(window.console);
+
+// renderowanie aplikacji do drzewa DOM
 ReactDom.render(<App/>, document.getElementById('root'));

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -37,12 +37,12 @@ const styles = StyleSheet.create({
 // ignorowanie warningów pochodzących z bibliotek
 const warnedComponents = ['ScrollView', 'TouchableOpacity'];
 const defineNewConsole = (oldConsole => ({
-  log: text => oldConsole.log(text),
-  info: text => oldConsole.info(text),
-  warn: text => {
+  log: (text) => oldConsole.log(text),
+  info: (text) => oldConsole.info(text),
+  warn: (text) => {
     let shouldIgnore = false;
     warnedComponents.forEach((name) => {
-      if (text.includes(name) && text.includes('Please update the following components:')) {
+      if (text.includes(`Please update the following components: ${name}`)) {
         shouldIgnore = true;
       }
     });
@@ -50,7 +50,7 @@ const defineNewConsole = (oldConsole => ({
       oldConsole.warn(text);
     }
   },
-  error: text => oldConsole.error(text)
+  error: (text) => oldConsole.error(text)
 }));
 window.console = defineNewConsole(window.console);
 


### PR DESCRIPTION
Biblioteka `react-native-web` korzysta z metod uznanych przez Reacta za deprecated, co powoduje denerwujące wyświetlanie warningów na konsoli:

![image](https://user-images.githubusercontent.com/37980016/71754325-f4c06900-2e85-11ea-8f64-4cad566f4bef.png)

Wprowadzone zmiany ignorują te konkretne warningi, dzięki czemu można się skupić na tych, na które mamy wpływ.