### PR TITLE
Usunięcie zbędnego pliku package.lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
plik `package.lock` już istnieje w katalogu `frontend` i tam ma być, ale nie powinno być innego takiego pliku, zatem został usunięty